### PR TITLE
Add support for tracking original value

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,20 +6,20 @@ Object.defineProperty(exports, "__esModule", {
 exports.RollbackError = undefined;
 
 exports.default = function (schema, opts) {
-  var options = (0, _lodash.merge)({}, defaultOptions, opts
+  var options = (0, _lodash.merge)({}, defaultOptions, opts);
 
   // get _id type from schema
-  );options._idType = schema.tree._id.type;
+  options._idType = schema.tree._id.type;
 
   // validate parameters
   (0, _assert2.default)(options.mongoose, '`mongoose` option must be defined');
   (0, _assert2.default)(options.name, '`name` option must be defined');
   (0, _assert2.default)(!schema.methods.data, 'conflicting instance method: `data`');
-  (0, _assert2.default)(options._idType, 'schema is missing an `_id` property'
+  (0, _assert2.default)(options._idType, 'schema is missing an `_id` property');
 
   // used to compare instance data snapshots. depopulates instance,
   // removes version key and object id
-  );schema.methods.data = function () {
+  schema.methods.data = function () {
     return this.toObject({
       depopulate: true,
       versionKey: false,
@@ -48,11 +48,11 @@ exports.default = function (schema, opts) {
         // get all patches that should be applied
         var apply = (0, _lodash.dropRightWhile)(patches, function (patch) {
           return patch.id !== patchId;
-        }
+        });
 
         // if the patches that are going to be applied are all existing patches,
         // the rollback attempts to rollback to the latest patch
-        );if (patches.length === apply.length) {
+        if (patches.length === apply.length) {
           return reject(new RollbackError('rollback to latest patch'));
         }
 
@@ -60,10 +60,10 @@ exports.default = function (schema, opts) {
         var state = {};
         apply.forEach(function (patch) {
           _fastJsonPatch2.default.applyPatch(state, patch.ops, true);
-        }
+        });
 
         // save new state and resolve with the resulting document
-        );_this.set((0, _lodash.merge)(data, state)).save().then(resolve).catch(reject);
+        _this.set((0, _lodash.merge)(data, state)).save().then(resolve).catch(reject);
       });
     });
   };
@@ -74,19 +74,19 @@ exports.default = function (schema, opts) {
   schema.statics.Patches = Patches;
   schema.virtual('patches').get(function () {
     return Patches;
-  }
+  });
 
   // after a document is initialized or saved, fresh snapshots of the
   // documents data are created
-  );var snapshot = function snapshot() {
+  var snapshot = function snapshot() {
     this._original = toJSON(this.data());
   };
   schema.post('init', snapshot);
-  schema.post('save', snapshot
+  schema.post('save', snapshot);
 
   // when a document is removed and `removePatches` is not set to false ,
   // all patch documents from the associated patch collection are also removed
-  );function deletePatches(document) {
+  function deletePatches(document) {
     var ref = document._id;
 
     return document.patches.find({ ref: document._id }).then(function (patches) {
@@ -104,21 +104,29 @@ exports.default = function (schema, opts) {
     deletePatches(this).then(function () {
       return next();
     }).catch(next);
-  }
+  });
 
   // when a document is saved, the json patch that reflects the changes is
   // computed. if the patch consists of one or more operations (meaning the
   // document has changed), a new patch document reflecting the changes is
   // added to the associated patch collection
-  );function createPatch(document) {
+  function createPatch(document) {
     var queryOptions = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
     var ref = document._id;
 
-    var ops = _fastJsonPatch2.default.compare(document.isNew ? {} : document._original || {}, toJSON(document.data())
+    var ops = _fastJsonPatch2.default.compare(document.isNew ? {} : document._original || {}, toJSON(document.data()));
 
     // don't save a patch when there are no changes to save
-    );if (!ops.length) {
+    if (!ops.length) {
       return _bluebird2.default.resolve();
+    }
+
+    // track original values if enabled
+    if (options.trackOriginalValue) {
+      ops.map(function (entry) {
+        var path = (0, _lodash.tail)(entry.path.split('/')).join('.');
+        entry.originalValue = (0, _lodash.get)(document.isNew ? {} : document._original, path);
+      });
     }
 
     // assemble patch data
@@ -287,7 +295,8 @@ var createPatchModel = function createPatchModel(options) {
 var defaultOptions = {
   includes: {},
   removePatches: true,
-  transforms: [_humps.pascalize, _humps.decamelize]
+  transforms: [_humps.pascalize, _humps.decamelize],
+  trackOriginalValue: false
 
   // used to convert bson to json - especially ObjectID references need
   // to be converted to hex strings so that the jsonpatch `compare` method


### PR DESCRIPTION
This PR adds the option to track the original value in the opts entries. The new entry structure is:
```javascript
[{
    "originalValue": "Private 2",
    "value": "Private 3",
    "path": "/name",
    "op": "replace"
}]
```

To enable the new feature you have to pass the following option to patchHistory plugin:
```javascript
PostSchema.plugin(patchHistory, {
  ...
  trackOriginalValue: true
})
```